### PR TITLE
Disabled passwords for admins by default

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,3 +5,4 @@ adminshell: "/bin/bash"
 adminusers:
   - {name: admin1, state: 'present', uid: 5001, groups: "{{admingroup}}", shell: "{{adminshell}}", pubkey: "ssh-rsa KEY admin1@example.com" }
   - {name: bad_admin2, state: 'absent', uid: 5002, groups: "{{admingroup}}", shell: "{{adminshell}}", pubkey: "ssh-rsa KEY admin2@example.com" }
+adminremove_passwords: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,7 +11,14 @@
     when: admingroupsudoers.changed
 
   - name: Add or remove admin users
-    user: "name={{item.name}} state={{item.state | default('present')}} uid={{item.uid}} group={{item.groups}} shell={{item.shell | default('/bin/bash')}}"
+    user: >
+      name={{item.name}}
+      # Default to no password. Required for sshd PasswordAuthentication no
+      password={{item.password | default('*')}}
+      state={{item.state | default('present')}}
+      uid={{item.uid}}
+      group={{item.groups}}
+      shell={{item.shell | default('/bin/bash')}}
     with_items: adminusers
 
   - name: Add ssh keys to admin users

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,13 +13,18 @@
   - name: Add or remove admin users
     user: >
       name={{item.name}}
-      # Default to no password. Required for sshd PasswordAuthentication no
-      password={{item.password | default('*')}}
       state={{item.state | default('present')}}
       uid={{item.uid}}
       group={{item.groups}}
       shell={{item.shell | default('/bin/bash')}}
     with_items: adminusers
+
+  - name: Remove passwords from admins (if remove_passwords is true)
+      name={{item.name}}
+      # No password. Required for sshd PasswordAuthentication no
+      password='*'
+    with_items: adminusers
+    when: adminremove_passwords
 
   - name: Add ssh keys to admin users
     authorized_key: user="{{item.name}}" key="{{item.pubkey}}"


### PR DESCRIPTION
This sets all the admin passwords to '*' which is similar to !! (the
previous setting) but means the account is not 'locked'. The result is
that users can't set a password (unless they do it as root).

This is needed if you set "PasswordAuthentication: no" in sshd_config.

This is another optional parameter for each user and the code was
getting kind of messy so I've reformatted the existing code.