### PR TITLE
Remove default users and handle missing adminusers

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,9 +4,9 @@ admingroup: "admin"
 adminshell: "/bin/bash"
 # If you don't want to add admingroup to sudoers - set admin_sudoers to False
 admin_sudoers: True
-adminusers:
-  - {name: admin1, state: 'present', uid: 5001, groups: "{{admingroup}}", shell: "{{adminshell}}", pubkey: "ssh-rsa KEY admin1@example.com" }
-  - {name: bad_admin2, state: 'absent', uid: 5002, groups: "{{admingroup}}", shell: "{{adminshell}}", pubkey: "ssh-rsa KEY admin2@example.com" }
-  - {name: rsyncuser1, state: 'present', uid: 5003, groups: "{{admingroup}}", shell: "{{adminshell}}", pubkey: "ssh-rsa KEY rsync1@example.com", options: 'command="/usr/local/bin/rrsync /allow/rrsync/here/directory",no-agent-forwarding,no-port-forwarding,no-pty,no-user-rc,no-X11-forwarding' }
+#adminusers:
+#  - {name: admin1, state: 'present', uid: 5001, groups: "{{admingroup}}", shell: "{{adminshell}}", pubkey: "ssh-rsa KEY admin1@example.com" }
+#  - {name: bad_admin2, state: 'absent', uid: 5002, groups: "{{admingroup}}", shell: "{{adminshell}}", pubkey: "ssh-rsa KEY admin2@example.com" }
+#  - {name: rsyncuser1, state: 'present', uid: 5003, groups: "{{admingroup}}", shell: "{{adminshell}}", pubkey: "ssh-rsa KEY rsync1@example.com", options: 'command="/usr/local/bin/rrsync /allow/rrsync/here/directory",no-agent-forwarding,no-port-forwarding,no-pty,no-user-rc,no-X11-forwarding' }
 
 adminremove_passwords: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,8 +18,8 @@
     user: >
       name={{item.name}}
       state={{item.state | default('present')}}
-      uid={{item.uid}}
-      group={{item.groups}}
+      uid={{item.uid | default('') }}
+      group={{item.groups | default('') }}
       shell={{item.shell | default('/bin/bash')}}
     with_items: adminusers | default({})
 
@@ -32,7 +32,7 @@
     user: >
       name={{item.name}}
       password='*'
-    with_items: adminusers
+    with_items: adminusers | default({})
     when: adminremove_passwords
 
   - name: Add ssh keys to admin users

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,7 +21,7 @@
       uid={{item.uid}}
       group={{item.groups}}
       shell={{item.shell | default('/bin/bash')}}
-    with_items: adminusers
+    with_items: adminusers | default({})
 
   - name: Remove wheel group in sudoers if admin group was added and the sudoers.d file for the admin group was added
     lineinfile: dest=/etc/sudoers state=absent regexp="^%wheel" validate='visudo -cf %s'
@@ -38,9 +38,9 @@
   - name: Add ssh keys to admin users
     authorized_key: user="{{item.name}}" key='{{item.pubkey}}'
     when: item.state == 'present' and item.pubkey is defined and item.options is undefined
-    with_items: adminusers
+    with_items: adminusers | default({})
 
   - name: Add key_options if option is
     authorized_key: user="{{item.name}}" key='{{item.pubkey}}' key_options='{{ item.options }}'
     when: item.state == 'present' and item.pubkey is defined and item.options is defined
-    with_items: adminusers
+    with_items: adminusers | default({})


### PR DESCRIPTION
A new user might well run this role without setting 'adminusers' and
this role creates some test users which need cleaning up. This change
just removes this default and handles when adminusers is not set.