### PR TITLE
Made the role Ansible2 compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Ansible Role to add local unix users
 
 # Calling the role
 
-When you call the role, it needs the "gather_subset: "!all" parameter. E.g.
+When you call the role, if your ansible version >= 2.1 it needs the "gather_subset: "!all" parameter. E.g.
 
 <pre>
 - name: Configure users

--- a/README.md
+++ b/README.md
@@ -2,6 +2,20 @@
 # ansible-role-users
 Ansible Role to add local unix users
 
+# Calling the role
+
+When you call the role, it needs the "gather_subset: "!all" parameter. E.g.
+
+<pre>
+- name: Configure users
+  hosts: admin_hosts
+  gather_subset: "!all"
+  roles:
+     - ansible-role-users
+</pre>
+
+This gathers enough info to be usable by the role, but doesn't try to ssh in which might by definition fail.
+
 # Role Variables
 
 <pre>
@@ -37,3 +51,4 @@ MIT
 
  - https://github.com/martbhell
  - https://github.com/peterjenkins1
+ - https://github.com/khappone

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,12 +1,12 @@
 ---
   - name: Find correct remote user
-    set_fact: remote_user="{{ ansible_ssh_user }}" should_become=true
-    ignore_errors: true
-
-  - name: Find correct remote user
     set_fact: remote_user="root"  should_become=false
     ignore_errors: true
     remote_user: "root"
+
+  - name: Find correct remote user
+    set_fact: remote_user="{{ ansible_user_id }}" should_become=true
+    ignore_errors: true
 
   - name: Create admin group
     group: "name={{admingroup}}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,9 +4,15 @@
     ignore_errors: true
     remote_user: "root"
 
-  - name: Find correct remote user
+  - name: Find correct remote user (Ansible >= 2.1 )
     set_fact: remote_user="{{ ansible_user_id }}" should_become=true
     ignore_errors: true
+    when: ansible_user_id is defined
+
+  - name: Find correct remote user (Ansible < 2.1 )
+    set_fact: remote_user="{{ ansible_ssh_user }}" should_become=true
+    ignore_errors: true
+    when: ansible_ssh_user is defined
 
   - name: Create admin group
     group: "name={{admingroup}}"


### PR DESCRIPTION
Ansible2 has some changes in naming and how it handles variables. These
changes make the role ansible2 compatible. This explicitly means that
the module is no logner compatbible with ansible1.