### PR TITLE
A real fix for getting the right login user

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,17 +4,15 @@ Ansible Role to add local unix users
 
 # Calling the role
 
-When you call the role, if your ansible version >= 2.1 it needs the "gather_subset: "!all" parameter. E.g.
+When you call the role, you need to set gather_facts to false.
 
 <pre>
 - name: Configure users
   hosts: admin_hosts
-  gather_subset: "!all"
+  gather_facts: false
   roles:
      - ansible-role-users
 </pre>
-
-This gathers enough info to be usable by the role, but doesn't try to ssh in which might by definition fail.
 
 # Role Variables
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,18 +1,19 @@
 ---
-  - name: Find correct remote user
+  - name: Test login in as current user
+    local_action: shell ssh -F ssh.config -o PasswordAuthentication=no {{ inventory_hostname }} "whoami"
+    ignore_errors: true
+    always_run: true
+    register: login_as_self
+
+  - name: Use root to login
     set_fact: remote_user="root"  should_become=false
-    ignore_errors: true
-    remote_user: "root"
+    always_run: true
+    when: login_as_self.rc != 0
 
-  - name: Find correct remote user (Ansible >= 2.1 )
-    set_fact: remote_user="{{ ansible_user_id }}" should_become=true
-    ignore_errors: true
-    when: ansible_user_id is defined
-
-  - name: Find correct remote user (Ansible < 2.1 )
-    set_fact: remote_user="{{ ansible_ssh_user }}" should_become=true
-    ignore_errors: true
-    when: ansible_ssh_user is defined
+  - name:  Use yourself to log in
+    set_fact: remote_user="{{ login_as_self.stdout_lines[0] }}" should_become=true
+    always_run: true
+    when: login_as_self.rc == 0
 
   - name: Create admin group
     group: "name={{admingroup}}"


### PR DESCRIPTION
Added more logic to actually figure out the login user. This should now
work on ansible 1, 2 and 2.1 consistently.

Added always_run: true to harmless task which are required for the rest
of the tasks to run. This was so that the role can be run succesfully
with --check.