### PR TITLE
Split the groups var to group and groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Can be done with this trick:
 <pre>
 newline: "\n"
 
-  - { name: multisshkeyuser, uid: 5004, group: "{{admingroup}}", groups: "agroup, bgroup", state: "present", shell: "{{adminshell}}", pubkey: "ssh-rsa KEY1 {{ newline }} ssh-rsa KEY2 {{ newline }} ssh-rsa KEY3" }
+  - { name: multisshkeyuser, uid: 5004, group: "{{admingroup}}", groups: "agroup,bgroup", state: "present", shell: "{{adminshell}}", pubkey: "ssh-rsa KEY1 {{ newline }} ssh-rsa KEY2 {{ newline }} ssh-rsa KEY3" }
 
 </pre>
 

--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@ More examples can be found in tests/test.yml:
 admingroup: "admin"
 adminshell: "/bin/bash"
 adminusers:
- - {name: admin1, state: 'present', uid: 5001, groups: "{{admingroup}}", shell: "{{adminshell}}", pubkey: "ssh-rsa KEY admin1@example.com" }
+ - {name: admin1, state: 'present', uid: 5001, group: "{{admingroup}}", shell: "{{adminshell}}", pubkey: "ssh-rsa KEY admin1@example.com" }
 adminremove_passwords: false
- - {name: badadmin2, state: 'absent', uid: 5001, groups: "{{admingroup}}", shell: "{{adminshell}}", pubkey: "ssh-rsa KEY badadmin2@example.com" }
- - {name: rsyncuser1, state: 'present', uid: 5003, groups: "{{admingroup}}", shell: "{{adminshell}}", pubkey: "ssh-rsa KEY rsync1@example.com", options: 'command="/usr/local/bin/rrsync /allow/rrsync/here/directory",no-agent-forwarding,no-port-forwarding,no-pty,no-user-rc,no-X11-forwarding' }
+ - {name: badadmin2, state: 'absent', uid: 5001, group: "{{admingroup}}", shell: "{{adminshell}}", pubkey: "ssh-rsa KEY badadmin2@example.com" }
+ - {name: rsyncuser1, state: 'present', uid: 5003, group: "{{admingroup}}", shell: "{{adminshell}}", pubkey: "ssh-rsa KEY rsync1@example.com", options: 'command="/usr/local/bin/rrsync /allow/rrsync/here/directory",no-agent-forwarding,no-port-forwarding,no-pty,no-user-rc,no-X11-forwarding' }
 </pre>
 
  - adminremove_passwords: True
@@ -38,7 +38,7 @@ Can be done with this trick:
 <pre>
 newline: "\n"
 
-  - { name: multisshkeyuser, uid: 5004, group: "{{admingroup}}", groups: "{{admingroup}}", state: "present", shell: "{{adminshell}}", pubkey: "ssh-rsa KEY1 {{ newline }} ssh-rsa KEY2 {{ newline }} ssh-rsa KEY3" }
+  - { name: multisshkeyuser, uid: 5004, group: "{{admingroup}}", groups: "agroup, bgroup", state: "present", shell: "{{adminshell}}", pubkey: "ssh-rsa KEY1 {{ newline }} ssh-rsa KEY2 {{ newline }} ssh-rsa KEY3" }
 
 </pre>
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,9 +5,9 @@ adminshell: "/bin/bash"
 # If you don't want to add admingroup to sudoers - set admin_sudoers to False
 admin_sudoers: True
 #adminusers:
-#  - {name: admin1, state: 'present', uid: 5001, groups: "{{admingroup}}", shell: "{{adminshell}}", pubkey: "ssh-rsa KEY admin1@example.com" }
-#  - {name: bad_admin2, state: 'absent', uid: 5002, groups: "{{admingroup}}", shell: "{{adminshell}}", pubkey: "ssh-rsa KEY admin2@example.com" }
-#  - {name: rsyncuser1, state: 'present', uid: 5003, groups: "{{admingroup}}", shell: "{{adminshell}}", pubkey: "ssh-rsa KEY rsync1@example.com", options: 'command="/usr/local/bin/rrsync /allow/rrsync/here/directory",no-agent-forwarding,no-port-forwarding,no-pty,no-user-rc,no-X11-forwarding' }
+#  - {name: admin1, state: 'present', uid: 5001, group: "{{admingroup}}", shell: "{{adminshell}}", pubkey: "ssh-rsa KEY admin1@example.com" }
+#  - {name: bad_admin2, state: 'absent', uid: 5002, group: "{{admingroup}}", shell: "{{adminshell}}", pubkey: "ssh-rsa KEY admin2@example.com" }
+#  - {name: rsyncuser1, state: 'present', uid: 5003, group: "{{admingroup}}", groups: "agroup, bgroup", shell: "{{adminshell}}", pubkey: "ssh-rsa KEY rsync1@example.com", options: 'command="/usr/local/bin/rrsync /allow/rrsync/here/directory",no-agent-forwarding,no-port-forwarding,no-pty,no-user-rc,no-X11-forwarding' }
 #
 #moreusers:
 #  - {name: someotheruser1, state: 'present', uid: 6001, shell: "{{adminshell}}" }

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,7 +7,7 @@ admin_sudoers: True
 #adminusers:
 #  - {name: admin1, state: 'present', uid: 5001, group: "{{admingroup}}", shell: "{{adminshell}}", pubkey: "ssh-rsa KEY admin1@example.com" }
 #  - {name: bad_admin2, state: 'absent', uid: 5002, group: "{{admingroup}}", shell: "{{adminshell}}", pubkey: "ssh-rsa KEY admin2@example.com" }
-#  - {name: rsyncuser1, state: 'present', uid: 5003, group: "{{admingroup}}", groups: "agroup, bgroup", shell: "{{adminshell}}", pubkey: "ssh-rsa KEY rsync1@example.com", options: 'command="/usr/local/bin/rrsync /allow/rrsync/here/directory",no-agent-forwarding,no-port-forwarding,no-pty,no-user-rc,no-X11-forwarding' }
+#  - {name: rsyncuser1, state: 'present', uid: 5003, group: "{{admingroup}}", groups: "agroup,bgroup", shell: "{{adminshell}}", pubkey: "ssh-rsa KEY rsync1@example.com", options: 'command="/usr/local/bin/rrsync /allow/rrsync/here/directory",no-agent-forwarding,no-port-forwarding,no-pty,no-user-rc,no-X11-forwarding' }
 #
 #moreusers:
 #  - {name: someotheruser1, state: 'present', uid: 6001, shell: "{{adminshell}}" }

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,7 +28,9 @@
       register: reg_add_admin_group
 
     - name: Create groups from a list
-      group: "name={{item.name}} gid={{item.gid}}"
+      group: 
+        name: "{{item.name}}"
+        gid: "{{item.gid | default(omit)}}"
       register: reg_add_group
       when: admin_list_of_groups is defined and admin_list_of_groups.0 is defined
       with_items: "{{ admin_list_of_groups }}"
@@ -53,7 +55,8 @@
         name: "{{item.name}}"
         state: "{{item.state | default('present')}}"
         uid: "{{item.uid | default(omit) }}"
-        group: "{{item.groups | default(omit) }}"
+        group: "{{item.group | default(omit) }}"
+        groups: "{{item.groups | default(omit) }}"
         shell: "{{item.shell | default('/bin/bash')}}"
       with_items: 
        - "{{ adminusers | default([]) }}"
@@ -74,7 +77,8 @@
         password: '*'
         state: "{{item.state | default('present')}}"
         uid: "{{item.uid | default(omit) }}"
-        group: "{{item.groups | default(omit) }}"
+        group: "{{item.group | default(omit) }}"
+        groups: "{{item.groups | default(omit) }}"
         shell: "{{item.shell | default('/bin/bash')}}"
       with_items: 
        - "{{ adminusers | default([]) }}"

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -9,6 +9,7 @@
        - {name: admin2, state: 'present', uid: 5002, group: "{{admingroup}}", shell: "{{adminshell}}", pubkey: "ssh-rsa KEY admin2@example.com", groups: "agroup" }
        - {name: admin3, state: 'present', uid: 5003, groups: "{{admingroup}}", shell: "{{adminshell}}", pubkey: "ssh-rsa KEY admin3@example.com" }
        - {name: admin4, state: 'present', uid: 5004, group: "{{admingroup}}", shell: "{{adminshell}}", pubkey: "ssh-rsa KEY admin4@example.com", groups: "bgroup" }
+       - {name: admin5, state: 'present', uid: 5005, group: "{{admingroup}}", shell: "{{adminshell}}", pubkey: "ssh-rsa KEY admin5@example.com", groups: "agroup,bgroup" }
      - moreusers:
        - {name: user1, state: 'present', uid: 6001, shell: "{{adminshell}}" }
        - {name: user2, state: 'present', uid: 6002 }

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -6,6 +6,7 @@
      - adminremove_passwords: True
      - adminusers:
        - {name: admin1, state: 'present', uid: 5001, group: "{{admingroup}}", shell: "{{adminshell}}", pubkey: "ssh-rsa KEY admin1@example.com" }
+       - {name: admin2, state: 'present', uid: 5002, group: "{{admingroup}}", shell: "{{adminshell}}", pubkey: "ssh-rsa KEY admin2@example.com", groups: "agroup, bgroup" }
      - moreusers:
        - {name: user1, state: 'present', uid: 6001, shell: "{{adminshell}}" }
        - {name: user2, state: 'present', uid: 6002 }
@@ -17,6 +18,9 @@
      - admin_root_keys:
        - { state: 'present', pubkey: "ssh-rsa KEY admin1@example.com" }
        - { state: 'absent', pubkey: "ssh-rsa KEY2 bad_admin2@example.com" }
-
+     - admin_list_of_groups:
+       - { name: agroup, gid: 27001 }
+       - { name: bgroup, gid: 27002 }
+     
    roles:
      - ansible-role-users

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -6,7 +6,9 @@
      - adminremove_passwords: True
      - adminusers:
        - {name: admin1, state: 'present', uid: 5001, group: "{{admingroup}}", shell: "{{adminshell}}", pubkey: "ssh-rsa KEY admin1@example.com" }
-       - {name: admin2, state: 'present', uid: 5002, group: "{{admingroup}}", shell: "{{adminshell}}", pubkey: "ssh-rsa KEY admin2@example.com", groups: "agroup, bgroup" }
+       - {name: admin2, state: 'present', uid: 5002, group: "{{admingroup}}", shell: "{{adminshell}}", pubkey: "ssh-rsa KEY admin2@example.com", groups: "agroup" }
+       - {name: admin3, state: 'present', uid: 5003, groups: "{{admingroup}}", shell: "{{adminshell}}", pubkey: "ssh-rsa KEY admin3@example.com" }
+       - {name: admin4, state: 'present', uid: 5004, group: "{{admingroup}}", shell: "{{adminshell}}", pubkey: "ssh-rsa KEY admin4@example.com", groups: "bgroup" }
      - moreusers:
        - {name: user1, state: 'present', uid: 6001, shell: "{{adminshell}}" }
        - {name: user2, state: 'present', uid: 6002 }

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -5,7 +5,7 @@
    vars:
      - adminremove_passwords: True
      - adminusers:
-       - {name: admin1, state: 'present', uid: 5001, groups: "{{admingroup}}", shell: "{{adminshell}}", pubkey: "ssh-rsa KEY admin1@example.com" }
+       - {name: admin1, state: 'present', uid: 5001, group: "{{admingroup}}", shell: "{{adminshell}}", pubkey: "ssh-rsa KEY admin1@example.com" }
      - moreusers:
        - {name: user1, state: 'present', uid: 6001, shell: "{{adminshell}}" }
        - {name: user2, state: 'present', uid: 6002 }


### PR DESCRIPTION
The user groups can now be set with the group and groups variables.
The group var sets the user's primary (initial) group and with the
groups var the additional groups can be specified (comma separated).
The old behaviour was that the groups vas was was set to the ansible
user module's group var preventing multiple groups to be specified.