### PR TITLE
Allow defining more user lists

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,6 +12,10 @@ admin_sudoers: True
 #moreusers:
 #  - {name: someotheruser1, state: 'present', uid: 6001, shell: "{{adminshell}}" }
 
+admin_list_of_user_lists:
+  - "{{ adminusers | default([]) }}"
+  - "{{ moreusers | default([]) }}"
+
 admin_root_keys:
 #  - { state: 'present', pubkey: "ssh-rsa KEY admin1@example.com" }
 #  - { state: 'absent', pubkey: "ssh-rsa KEY2 bad_admin2@example.com" }

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,7 +8,7 @@
 
   - name: Use root to login
     set_fact: 
-      remote_user: "root" 
+      remote_user: "root"
       should_become: false
     always_run: true
     failed_when: login_as_self.rc is not defined
@@ -44,7 +44,7 @@
 
     - name: Install Python SE Linux support (needed on CentOS7 with Enforcing)
       package: 
-        name: libselinux-python 
+        name: libselinux-python
         state: present
       when: ansible_os_family == "RedHat" and ansible_distribution_major_version >= 7
 
@@ -61,9 +61,9 @@
 
     - name: Ensure /etc/sudoers.d is scanned by sudo
       lineinfile: 
-        dest: "/etc/sudoers"
-        regexp: "#includedir\s+/etc/sudoers.d"
-        line: "#includedir /etc/sudoers.d"
+        dest: '/etc/sudoers'
+        regexp: '#includedir\s+/etc/sudoers.d'
+        line: '#includedir /etc/sudoers.d'
       when: admin_sudoers
 
     - name: Add or remove users from the lists in admin_list_of_user_lists

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,19 +1,23 @@
 ---
   - name: Test login in as current/configured user
-    local_action: shell ssh {{ ssh_extra_args }} {{ inventory_hostname }} whoami
+    local_action: shell ssh {{ssh_extra_args}} {{inventory_hostname}} whoami
     ignore_errors: true
     always_run: true
     changed_when: login_as_self.rc is not defined
     register: login_as_self
 
   - name: Use root to login
-    set_fact: remote_user="root" should_become=false
+    set_fact: 
+      remote_user: "root" 
+      should_become: false
     always_run: true
     failed_when: login_as_self.rc is not defined
     when: login_as_self.rc != 0
 
   - name: Use current/configured user to log in
-    set_fact: remote_user="{{ login_as_self.stdout_lines[0] }}" should_become=true
+    set_fact: 
+      remote_user: "{{login_as_self.stdout_lines[0]}}" 
+      should_become: true
     always_run: true
     failed_when: login_as_self.rc is not defined
     when: login_as_self.rc == 0
@@ -39,27 +43,36 @@
         label: "{{ user.name }}"
 
     - name: Install Python SE Linux support (needed on CentOS7 with Enforcing)
-      package: name=libselinux-python state=present
+      package: 
+        name: libselinux-python 
+        state: present
       when: ansible_os_family == "RedHat" and ansible_distribution_major_version >= 7
 
     - name: Create sudoers file for admin group
-      copy: dest=/etc/sudoers.d/{{ admingroup }} owner=root group=root mode=0440
-            content='%{{ admingroup }} ALL=(ALL) NOPASSWD:ALL'
-            validate='visudo -cf %s'
+      copy: 
+        dest: "/etc/sudoers.d/{{admingroup}}"
+        owner: "root"
+        group: "root"
+        mode: 0440
+        content: '%{{admingroup}} ALL=(ALL) NOPASSWD:ALL'
+        validate: 'visudo -cf %s'
       register: reg_add_sudoers_file_admins
       when: admin_sudoers
 
     - name: Ensure /etc/sudoers.d is scanned by sudo
-      lineinfile: dest=/etc/sudoers regexp="#includedir\s+/etc/sudoers.d" line="#includedir /etc/sudoers.d"
+      lineinfile: 
+        dest: "/etc/sudoers"
+        regexp: "#includedir\s+/etc/sudoers.d"
+        line: "#includedir /etc/sudoers.d"
       when: admin_sudoers
 
     - name: Add or remove users from the lists in admin_list_of_user_lists
       user:
         name: "{{user.name}}"
         state: "{{user.state | default('present')}}"
-        uid: "{{user.uid | default(omit) }}"
-        group: "{{user.group | default(omit) }}"
-        groups: "{{user.groups | default(omit) }}"
+        uid: "{{user.uid | default(omit)}}"
+        group: "{{user.group | default(omit)}}"
+        groups: "{{user.groups | default(omit)}}"
         shell: "{{user.shell | default('/bin/bash')}}"
         comment: "{{user.comment | default(omit)}}"
         remove: "{{user.remove | default(omit)}}"
@@ -82,9 +95,9 @@
         name: "{{user.name}}"
         password: '*'
         state: "{{user.state | default('present')}}"
-        uid: "{{user.uid | default(omit) }}"
-        group: "{{user.group | default(omit) }}"
-        groups: "{{user.groups | default(omit) }}"
+        uid: "{{user.uid | default(omit)}}"
+        group: "{{user.group | default(omit)}}"
+        groups: "{{user.groups | default(omit)}}"
         shell: "{{user.shell | default('/bin/bash')}}"
         comment: "{{user.comment | default(omit)}}"
         remove: "{{user.remove | default(omit)}}"
@@ -98,7 +111,7 @@
       authorized_key: 
         user: "{{user.name}}" 
         key: '{{user.pubkey}}' 
-        key_options: '{{ user.options | default(omit) }}'
+        key_options: '{{user.options | default(omit)}}'
       when: user.state == 'present' and user.pubkey is defined
       with_items: "{{ admin_list_of_user_lists | default([]) }}"
       loop_control:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,7 +7,7 @@
     register: login_as_self
 
   - name: Use root to login
-    set_fact: 
+    set_fact:
       remote_user: "root"
       should_become: false
     always_run: true
@@ -15,8 +15,8 @@
     when: login_as_self.rc != 0
 
   - name: Use current/configured user to log in
-    set_fact: 
-      remote_user: "{{login_as_self.stdout_lines[0]}}" 
+    set_fact:
+      remote_user: "{{login_as_self.stdout_lines[0]}}"
       should_become: true
     always_run: true
     failed_when: login_as_self.rc is not defined
@@ -32,7 +32,7 @@
       register: reg_add_admin_group
 
     - name: Create groups from a list
-      group: 
+      group:
         name: "{{user.name}}"
         gid: "{{user.gid | default(omit)}}"
       register: reg_add_group
@@ -43,13 +43,13 @@
         label: "{{ user.name }}"
 
     - name: Install Python SE Linux support (needed on CentOS7 with Enforcing)
-      package: 
+      package:
         name: libselinux-python
         state: present
       when: ansible_os_family == "RedHat" and ansible_distribution_major_version >= 7
 
     - name: Create sudoers file for admin group
-      copy: 
+      copy:
         dest: "/etc/sudoers.d/{{admingroup}}"
         owner: "root"
         group: "root"
@@ -60,7 +60,7 @@
       when: admin_sudoers
 
     - name: Ensure /etc/sudoers.d is scanned by sudo
-      lineinfile: 
+      lineinfile:
         dest: '/etc/sudoers'
         regexp: '#includedir\s+/etc/sudoers.d'
         line: '#includedir /etc/sudoers.d'
@@ -84,7 +84,7 @@
     - name: Remove wheel group in sudoers if admin group was added and the sudoers.d file for the admin group was added
       lineinfile:
         dest: /etc/sudoers
-        state: absent 
+        state: absent
         regexp: "^%wheel"
         validate: 'visudo -cf %s'
       when: reg_add_admin_group.changed and reg_add_sudoers_file_admins.changed and admin_sudoers
@@ -108,9 +108,9 @@
         label: "{{ user.name }}"
 
     - name: Add ssh keys and use key_options if option is used
-      authorized_key: 
-        user: "{{user.name}}" 
-        key: '{{user.pubkey}}' 
+      authorized_key:
+        user: "{{user.name}}"
+        key: '{{user.pubkey}}'
         key_options: '{{user.options | default(omit)}}'
       when: user.state == 'present' and user.pubkey is defined
       with_items: "{{ admin_list_of_user_lists | default([]) }}"
@@ -119,8 +119,8 @@
         label: "{{ user.name }}"
 
     - name: Add or remove ssh keys to root user
-      authorized_key: 
-        user: "root" 
+      authorized_key:
+        user: "root"
         key: '{{user.pubkey}}'
         state: "{{user.state | default('present')}}"
       when: user.pubkey is defined

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -33,14 +33,14 @@
 
     - name: Create groups from a list
       group:
-        name: "{{user.name}}"
-        gid: "{{user.gid | default(omit)}}"
+        name: "{{group.name}}"
+        gid: "{{group.gid | default(omit)}}"
       register: reg_add_group
       when: admin_list_of_groups is defined and admin_list_of_groups.0 is defined
       with_items: "{{ admin_list_of_groups }}"
       loop_control:
-        loop_var: user
-        label: "{{ user.name }}"
+        loop_var: group
+        label: "{{ group.name }}"
 
     - name: Install Python SE Linux support (needed on CentOS7 with Enforcing)
       package:
@@ -79,7 +79,7 @@
       with_items: "{{ admin_list_of_user_lists | default([]) }}"
       loop_control:
         loop_var: user
-        label: "{{ user.name }}"
+        label: "{{ user.name }} {{ user.state }}"
 
     - name: Remove wheel group in sudoers if admin group was added and the sudoers.d file for the admin group was added
       lineinfile:
@@ -90,7 +90,7 @@
       when: reg_add_admin_group.changed and reg_add_sudoers_file_admins.changed and admin_sudoers
 
       # No password. Required for sshd PasswordAuthentication no
-    - name: Remove passwords from present adminusers and moreusers if adminremove_passwords is True
+    - name: Remove passwords from present users if adminremove_passwords is True
       user:
         name: "{{user.name}}"
         password: '*'
@@ -118,16 +118,16 @@
         loop_var: user
         label: "{{ user.name }}"
 
-    - name: Add or remove ssh keys to root user
+    - name: Add to or remove ssh keys from root user
       authorized_key:
         user: "root"
-        key: '{{user.pubkey}}'
-        state: "{{user.state | default('present')}}"
-      when: user.pubkey is defined
+        key: '{{key.pubkey}}'
+        state: "{{key.state | default('present')}}"
+      when: key.pubkey is defined
       with_items: "{{ admin_root_keys | default([]) }}"
       loop_control:
-        loop_var: user
-        label: "{{ user.pubkey }}"
+        loop_var: key
+        label: "{{ key.pubkey }}"
 
     # end of block
     remote_user: "{{ remote_user }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -88,9 +88,7 @@
         shell: "{{user.shell | default('/bin/bash')}}"
         comment: "{{user.comment | default(omit)}}"
         remove: "{{user.remove | default(omit)}}"
-      with_items: 
-       - "{{ adminusers | default([]) }}"
-       - "{{ moreusers | default([]) }}"
+      with_items: "{{ admin_list_of_user_lists | default([]) }}"
       when: adminremove_passwords and user.state == 'present'
       loop_control:
         loop_var: user
@@ -102,9 +100,7 @@
         key: '{{user.pubkey}}' 
         key_options: '{{ user.options | default(omit) }}'
       when: user.state == 'present' and user.pubkey is defined
-      with_items: 
-       - "{{ adminusers | default([]) }}"
-       - "{{ moreusers | default([]) }}"
+      with_items: "{{ admin_list_of_user_lists | default([]) }}"
       loop_control:
         loop_var: user
         label: "{{ user.name }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -121,13 +121,14 @@
     - name: Add to or remove ssh keys from root user
       authorized_key:
         user: "root"
-        key: '{{key.pubkey}}'
-        state: "{{key.state | default('present')}}"
-      when: key.pubkey is defined
+        key: '{{akey.pubkey}}'
+        state: "{{akey.state | default('present')}}"
+      when: akey.pubkey is defined
       with_items: "{{ admin_root_keys | default([]) }}"
       loop_control:
-        loop_var: key
-        label: "{{ key.pubkey }}"
+        loop_var: akey
+        label: "{{ akey.pubkey }}"
+        # use a loop_var that is not the same as a parameter of the module (key)
 
     # end of block
     remote_user: "{{ remote_user }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -53,7 +53,7 @@
       lineinfile: dest=/etc/sudoers regexp="#includedir\s+/etc/sudoers.d" line="#includedir /etc/sudoers.d"
       when: admin_sudoers
 
-    - name: Add or remove users from the adminusers and moreusers lists
+    - name: Add or remove users from the lists in admin_list_of_user_lists
       user:
         name: "{{user.name}}"
         state: "{{user.state | default('present')}}"
@@ -63,9 +63,7 @@
         shell: "{{user.shell | default('/bin/bash')}}"
         comment: "{{user.comment | default(omit)}}"
         remove: "{{user.remove | default(omit)}}"
-      with_items: 
-       - "{{ adminusers | default([]) }}"
-       - "{{ moreusers | default([]) }}"
+      with_items: "{{ admin_list_of_user_lists | default([]) }}"
       loop_control:
         loop_var: user
         label: "{{ user.name }}"

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -23,6 +23,15 @@
        - {name: user6, state: 'present', uid: 6006, pubkey: "ssh-rsa KEY6 user6@example.com", options: 'command="/usr/local/bin/rrsync /allow/rrsync/here/directory",no-agent-forwarding,no-port-forwarding,no-pty,no-user-rc,no-X11-forwarding' }
        - {name: user7, state: 'absent', uid: 6007, pubkey: "ssh-rsa KEY6 user6@example.com", options: 'command="/usr/local/bin/rrsync /allow/rrsync/here/directory",no-agent-forwarding,no-port-forwarding,no-pty,no-user-rc,no-X11-forwarding' }
        - {name: user8, state: 'absent', uid: 6008, comment: "comment1", remove: "yes" }
+     - anotheruserlisthere:
+       - {name: training1, state: 'present', uid: 7001, shell: "{{adminshell}}" }
+       - {name: training2, state: 'present', uid: 7002 }
+       - {name: training3, state: 'absent', uid: 7003 }
+     - admin_list_of_user_lists:
+       - "{{ adminusers | default([]) }}"
+       - "{{ moreusers | default([]) }}"
+       - "{{ anotheruserlisthere | default([]) }}"
+ 
      - admin_root_keys:
        - { state: 'present', pubkey: "ssh-rsa KEY admin1@example.com" }
        - { state: 'absent', pubkey: "ssh-rsa KEY2 bad_admin2@example.com" }


### PR DESCRIPTION
Bonus updates:
 - closes #15 
 - work over yaml syntax - all tasks are now using : instead of =
 - removed whitespaces at the end of lines
 - updated task names
 - change loop label to display user and if its state