### PR TITLE
Made user bootstrapping more configurable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,9 @@
 ---
 # defaults for ansible-role-users
+# Bootstrap user which can create the accounts
+# Can be e.g. root, or cloud-user, or ubuntu
+bootstrap_user: "root"
+
 admingroup: "admin"
 adminshell: "/bin/bash"
 # If you don't want to add admingroup to sudoers - set admin_sudoers to False

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,8 +6,8 @@
     changed_when: login_as_self.rc is not defined
     register: login_as_self
 
-  - name: Use root to login
-    set_fact: remote_user="root" should_become=false
+  - name: Use bootstrap_user to login
+    set_fact: remote_user="{{ bootstrap_user }}" should_become=true
     always_run: true
     failed_when: login_as_self.rc is not defined
     when: login_as_self.rc != 0


### PR DESCRIPTION
Added option for bootstrap_user for user creation. This means you can
use non-root users to bootstrap other users (in e.g. cloud environments)